### PR TITLE
Yasuhirok dev

### DIFF
--- a/src/erpc/erpc_arduino_uart_transport.cpp
+++ b/src/erpc/erpc_arduino_uart_transport.cpp
@@ -9,7 +9,12 @@
 #include "erpc_arduino_uart_transport.h"
 #include "Arduino.h"
 #include "wiring_private.h"
-
+#define DEBUG
+#ifdef DEBUG
+#define DBG_PRINTF(fmt, ...) Serial.printf("%s %d: "  fmt, "uart.cpp", __LINE__, ##__VA_ARGS__)
+#else
+#define DBG_PRINTF(fmt, ...)
+#endif
 using namespace erpc;
 
 #define NO_RTS_PIN 255
@@ -20,7 +25,8 @@ EUart::EUart(SERCOM *_s, uint8_t _pinRX, uint8_t _pinTX, SercomRXPad _padRX, Ser
 {
 }
 
-EUart::EUart(SERCOM *_s, uint8_t _pinRX, uint8_t _pinTX, SercomRXPad _padRX, SercomUartTXPad _padTX, uint8_t _pinRTS, uint8_t _pinCTS)
+EUart::EUart(SERCOM *_s, uint8_t _pinRX, uint8_t _pinTX, SercomRXPad _padRX, SercomUartTXPad _padTX, uint8_t _pinRTS, uint8_t _pinCTS) :
+  is_waiting_for_read{ false }, sem_read{ 0 }, request_size{ 0 }, sem_write{ 0 }
 {
   sercom = _s;
   uc_pinRX = _pinRX;
@@ -105,6 +111,11 @@ void EUart::IrqHandler()
         *pul_outsetRTS = ul_pinMaskRTS;
       }
     }
+    if (is_waiting_for_read)
+    {
+      is_waiting_for_read = false;
+      sem_read.putFromISR();
+    }
   }
 
   if (sercom->isDataRegisterEmptyUART())
@@ -114,6 +125,14 @@ void EUart::IrqHandler()
       uint8_t data = txBuffer.read_char();
 
       sercom->writeDataUART(data);
+      if (request_size > 0)
+      {
+        --request_size;
+        if (request_size == 0)
+        {
+          sem_write.putFromISR();
+        }
+      }
     }
     else
     {
@@ -251,6 +270,39 @@ SercomParityMode EUart::extractParity(uint16_t config)
   }
 }
 
+void EUart::waitForRead()
+{
+  noInterrupts();
+  if (available() > 0)
+  {
+    interrupts();
+    return;
+  }
+  is_waiting_for_read = true;
+  interrupts();
+  sem_read.get(Semaphore::kWaitForever);
+}
+
+void EUart::waitForWrite(size_t n)
+{
+  if (n == 0)
+  {
+    return;
+  }
+  noInterrupts();
+  int avail = txBuffer.availableForStore();
+  int x = txBuffer.available();
+  if (n <= avail)
+  {
+    interrupts();
+    return;
+  }
+  request_size = n - avail;
+  interrupts();
+  DBG_PRINTF("%d, %d, %d, %d\n", n, avail, request_size, x);
+  sem_write.get(Semaphore::kWaitForever);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Variables
 ////////////////////////////////////////////////////////////////////////////////
@@ -259,7 +311,7 @@ SercomParityMode EUart::extractParity(uint16_t config)
 // Code
 ////////////////////////////////////////////////////////////////////////////////
 
-UartTransport::UartTransport(HardwareSerial *uartDrv, unsigned long baudrate)
+UartTransport::UartTransport(HardwareSerialEx *uartDrv, unsigned long baudrate)
     : m_uartDrv(uartDrv), m_baudrate(baudrate)
 {
 }
@@ -278,9 +330,10 @@ erpc_status_t UartTransport::init(void)
 erpc_status_t UartTransport::underlyingReceive(uint8_t *data, uint32_t size)
 {
   uint32_t bytesRead = 0;
+  DBG_PRINTF("write %d\n", size);
   while (bytesRead < size)
   {
-    while (!m_uartDrv->available()) delay(1);
+    waitMessage();
 
     const int c = m_uartDrv->read();
     if (c < 0) continue;
@@ -292,9 +345,11 @@ erpc_status_t UartTransport::underlyingReceive(uint8_t *data, uint32_t size)
 erpc_status_t UartTransport::underlyingSend(const uint8_t *data, uint32_t size)
 {
   uint32_t sentSize = 0;
+  DBG_PRINTF("read %d\n", size);
   while (sentSize < size)
   {
     const uint32_t sendSize = min(size - sentSize, 256);
+    //m_uartDrv->waitForWrite(sendSize);
     sentSize += m_uartDrv->write(&data[sentSize], sendSize);
     delay(4);
   }
@@ -308,4 +363,13 @@ bool UartTransport::hasMessage()
     return true;
   }
   return false;
+}
+
+void UartTransport::waitMessage()
+{
+  if (hasMessage())
+  {
+    return;
+  }
+  m_uartDrv->waitForRead();
 }

--- a/src/erpc/erpc_arduino_uart_transport.cpp
+++ b/src/erpc/erpc_arduino_uart_transport.cpp
@@ -179,12 +179,6 @@ int EUart::read()
       *pul_outclrRTS = ul_pinMaskRTS;
     }
   }
-#ifdef UNIT_TEST
-  if (c < 0)
-  {
-    readBusywaitCount++;
-  }
-#endif
 
   return c;
 }
@@ -200,9 +194,6 @@ size_t EUart::write(const uint8_t data)
     // spin lock until a spot opens up in the buffer
     while (txBuffer.isFull())
     {
-#ifdef UNIT_TEST
-      writeBusywaitCount++;
-#endif
       uint8_t interruptsEnabled = ((__get_PRIMASK() & 0x1) == 0);
 
       if (interruptsEnabled)

--- a/src/erpc/erpc_arduino_uart_transport.cpp
+++ b/src/erpc/erpc_arduino_uart_transport.cpp
@@ -9,12 +9,7 @@
 #include "erpc_arduino_uart_transport.h"
 #include "Arduino.h"
 #include "wiring_private.h"
-#define DEBUG
-#ifdef DEBUG
-#define DBG_PRINTF(fmt, ...) Serial.printf("%s %d: "  fmt, "uart.cpp", __LINE__, ##__VA_ARGS__)
-#else
-#define DBG_PRINTF(fmt, ...)
-#endif
+
 using namespace erpc;
 
 #define NO_RTS_PIN 255

--- a/src/erpc/erpc_arduino_uart_transport.cpp
+++ b/src/erpc/erpc_arduino_uart_transport.cpp
@@ -299,7 +299,7 @@ void EUart::waitForWrite(size_t n)
   }
   request_size = n - avail;
   interrupts();
-  DBG_PRINTF("%d, %d, %d, %d\n", n, avail, request_size, x);
+  //DBG_PRINTF("%d, %d, %d, %d\n", n, avail, request_size, x);
   sem_write.get(Semaphore::kWaitForever);
 }
 
@@ -330,7 +330,7 @@ erpc_status_t UartTransport::init(void)
 erpc_status_t UartTransport::underlyingReceive(uint8_t *data, uint32_t size)
 {
   uint32_t bytesRead = 0;
-  DBG_PRINTF("write %d\n", size);
+  //DBG_PRINTF("read %d\n", size);
   while (bytesRead < size)
   {
     waitMessage();
@@ -345,13 +345,13 @@ erpc_status_t UartTransport::underlyingReceive(uint8_t *data, uint32_t size)
 erpc_status_t UartTransport::underlyingSend(const uint8_t *data, uint32_t size)
 {
   uint32_t sentSize = 0;
-  DBG_PRINTF("read %d\n", size);
+  //DBG_PRINTF("write %d\n", size);
   while (sentSize < size)
   {
-    const uint32_t sendSize = min(size - sentSize, 256);
-    //m_uartDrv->waitForWrite(sendSize);
+    const uint32_t sendSize = min(size - sentSize, static_cast<uint32_t>(255));
+    m_uartDrv->waitForWrite(sendSize);
     sentSize += m_uartDrv->write(&data[sentSize], sendSize);
-    delay(4);
+    //delay(4);
   }
   return kErpcStatus_Success; // return size != offset ? kErpcStatus_SendFailed : kErpcStatus_Success;
 }

--- a/src/erpc/erpc_arduino_uart_transport.h
+++ b/src/erpc/erpc_arduino_uart_transport.h
@@ -13,7 +13,6 @@
 #include "Arduino.h"
 #include <stdlib.h>
 
-//#define UNIT_TEST
 
 /*!
  * @addtogroup uart_transport
@@ -51,10 +50,6 @@ class HardwareSerialEx : public HardwareSerial
 
     virtual void waitForRead() = 0;
     virtual void waitForWrite(size_t) = 0;
-#ifdef UNIT_TEST
-    inline virtual uint32_t getReadBusywaitCount() { return UINT32_MAX; };
-    inline virtual uint32_t getWriteBusywaitCount() { return UINT32_MAX; };
-#endif
 };
 
 class EUart : public HardwareSerialEx
@@ -79,10 +74,7 @@ class EUart : public HardwareSerialEx
 
     virtual void waitForRead() override;
     virtual void waitForWrite(size_t n) override;
-#ifdef UNIT_TEST
-    inline virtual uint32_t getReadBusywaitCount() override { return readBusywaitCount; };
-    inline virtual uint32_t getWriteBusywaitCount() override { return writeBusywaitCount; };
-#endif
+
   private:
     SERCOM *sercom;
     RingBufferN<4096> rxBuffer;
@@ -102,10 +94,6 @@ class EUart : public HardwareSerialEx
     Semaphore sem_read;
     volatile size_t request_size;
     Semaphore sem_write;
-#ifdef UNIT_TEST
-    uint32_t readBusywaitCount;
-    uint32_t writeBusywaitCount;
-#endif
 
     SercomNumberStopBit extractNbStopBit(uint16_t config);
     SercomUartCharSize extractCharSize(uint16_t config);
@@ -144,10 +132,6 @@ public:
     virtual bool hasMessage(void);
 
     virtual void waitMessage(void) override;
-#ifdef UNIT_TEST
-    inline uint32_t getReadBusywaitCount() { return m_uartDrv->getReadBusywaitCount(); };
-    inline uint32_t getWriteBusywaitCount() { return m_uartDrv->getWriteBusywaitCount(); };
-#endif
 
 protected:
     HardwareSerialEx *m_uartDrv; /*!< Access structure of the USART Driver */

--- a/src/erpc/erpc_arduino_uart_transport.h
+++ b/src/erpc/erpc_arduino_uart_transport.h
@@ -13,7 +13,7 @@
 #include "Arduino.h"
 #include <stdlib.h>
 
-#define UNIT_TEST
+//#define UNIT_TEST
 
 /*!
  * @addtogroup uart_transport
@@ -51,6 +51,10 @@ class HardwareSerialEx : public HardwareSerial
 
     virtual void waitForRead() = 0;
     virtual void waitForWrite(size_t) = 0;
+#ifdef UNIT_TEST
+    inline virtual uint32_t getReadBusywaitCount() { return UINT32_MAX; };
+    inline virtual uint32_t getWriteBusywaitCount() { return UINT32_MAX; };
+#endif
 };
 
 class EUart : public HardwareSerialEx
@@ -76,8 +80,8 @@ class EUart : public HardwareSerialEx
     virtual void waitForRead() override;
     virtual void waitForWrite(size_t n) override;
 #ifdef UNIT_TEST
-    inline uint32_t getReadBusywaitCount() { return readBusywaitCount; };
-    inline uint32_t getWriteBusywaitCount() { return writeBusywaitCount; };
+    inline virtual uint32_t getReadBusywaitCount() override { return readBusywaitCount; };
+    inline virtual uint32_t getWriteBusywaitCount() override { return writeBusywaitCount; };
 #endif
   private:
     SERCOM *sercom;
@@ -140,6 +144,10 @@ public:
     virtual bool hasMessage(void);
 
     virtual void waitMessage(void) override;
+#ifdef UNIT_TEST
+    inline uint32_t getReadBusywaitCount() { return m_uartDrv->getReadBusywaitCount(); };
+    inline uint32_t getWriteBusywaitCount() { return m_uartDrv->getWriteBusywaitCount(); };
+#endif
 
 protected:
     HardwareSerialEx *m_uartDrv; /*!< Access structure of the USART Driver */

--- a/src/erpc/erpc_arduino_uart_transport.h
+++ b/src/erpc/erpc_arduino_uart_transport.h
@@ -13,6 +13,8 @@
 #include "Arduino.h"
 #include <stdlib.h>
 
+#define UNIT_TEST
+
 /*!
  * @addtogroup uart_transport
  * @{
@@ -73,7 +75,10 @@ class EUart : public HardwareSerialEx
 
     virtual void waitForRead() override;
     virtual void waitForWrite(size_t n) override;
-
+#ifdef UNIT_TEST
+    inline uint32_t getReadBusywaitCount() { return readBusywaitCount; };
+    inline uint32_t getWriteBusywaitCount() { return writeBusywaitCount; };
+#endif
   private:
     SERCOM *sercom;
     RingBufferN<4096> rxBuffer;
@@ -93,6 +98,10 @@ class EUart : public HardwareSerialEx
     Semaphore sem_read;
     volatile size_t request_size;
     Semaphore sem_write;
+#ifdef UNIT_TEST
+    uint32_t readBusywaitCount;
+    uint32_t writeBusywaitCount;
+#endif
 
     SercomNumberStopBit extractNbStopBit(uint16_t config);
     SercomUartCharSize extractCharSize(uint16_t config);

--- a/src/erpc/erpc_setup_arduino_uart.cpp
+++ b/src/erpc/erpc_setup_arduino_uart.cpp
@@ -21,7 +21,7 @@ static ManuallyConstructed<UartTransport> s_transport;
 ////////////////////////////////////////////////////////////////////////////////
 // Code
 ////////////////////////////////////////////////////////////////////////////////
-erpc_transport_t erpc_transport_uart_init(HardwareSerial *port, unsigned long baudrate)
+erpc_transport_t erpc_transport_uart_init(HardwareSerialEx *port, unsigned long baudrate)
 {
     s_transport.construct(port, baudrate);
     if (s_transport->init() == kErpcStatus_Success)

--- a/src/erpc/erpc_setup_arduino_uart.h
+++ b/src/erpc/erpc_setup_arduino_uart.h
@@ -18,7 +18,7 @@
 
 #include <stdint.h>
 
-erpc_transport_t  erpc_transport_uart_init(HardwareSerial *port, unsigned long baudrate = 115200);
+erpc_transport_t  erpc_transport_uart_init(HardwareSerialEx *port, unsigned long baudrate = 115200);
 
 void erpc_transport_uart_deinit(void);
 

--- a/src/erpc/erpc_simple_server.cpp
+++ b/src/erpc/erpc_simple_server.cpp
@@ -200,14 +200,8 @@ erpc_status_t SimpleServer::poll(void)
 {
     if (m_isServerOn)
     {
-        if (m_transport->hasMessage())
-        {
-            return runInternal();
-        }
-        else
-        {
-            return kErpcStatus_Success;
-        }
+        m_transport->waitMessage();
+        return runInternal();
     }
     return kErpcStatus_ServerIsDown;
 }

--- a/src/erpc/erpc_transport.h
+++ b/src/erpc/erpc_transport.h
@@ -76,7 +76,7 @@ namespace erpc
      *
      * @retval True when a message is available to process, else false.
      */
-       bool hasMessage(void){ return true; }
+        virtual bool hasMessage(void){ return true; }
 
         /*!
      * @brief This functions sets the CRC-16 implementation.
@@ -84,6 +84,13 @@ namespace erpc
      * @param[in] crcImpl Object containing crc-16 compute function.
      */
         virtual void setCrc16(Crc16 *crcImpl){ (void)crcImpl; };
+
+        /*!
+     * @brief Wait for an incoming message.
+     * 
+     * @retval wait until a message is available
+     */
+        virtual void waitMessage(void) { }
     };
 
     /*!

--- a/src/erpc_Unified_init.cpp
+++ b/src/erpc_Unified_init.cpp
@@ -96,8 +96,10 @@ void runServer(void *arg)
     /* run server */
     while (true)
     {
-        g_server.poll();
-        delay(20);
+        if (g_server.poll() != kErpcStatus_Success) 
+        {
+            delay(20);
+        }
     }
 }
 


### PR DESCRIPTION
# Network performance improvement

- Added blocking mode read.
- Added blocking mode write.

## Current performance
```
$ ping -c 10 192.168.6.6
PING 192.168.6.6 (192.168.6.6) 56(84) bytes of data.
64 bytes from 192.168.6.6: icmp_seq=1 ttl=254 time=85.3 ms
64 bytes from 192.168.6.6: icmp_seq=2 ttl=254 time=100 ms
64 bytes from 192.168.6.6: icmp_seq=3 ttl=254 time=128 ms
64 bytes from 192.168.6.6: icmp_seq=4 ttl=254 time=42.0 ms
64 bytes from 192.168.6.6: icmp_seq=5 ttl=254 time=79.0 ms
64 bytes from 192.168.6.6: icmp_seq=6 ttl=254 time=93.0 ms
64 bytes from 192.168.6.6: icmp_seq=7 ttl=254 time=110 ms
64 bytes from 192.168.6.6: icmp_seq=8 ttl=254 time=51.7 ms
64 bytes from 192.168.6.6: icmp_seq=9 ttl=254 time=52.3 ms
64 bytes from 192.168.6.6: icmp_seq=10 ttl=254 time=74.7 ms

--- 192.168.6.6 ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9015ms
rtt min/avg/max/mdev = 41.973/81.631/128.251/26.187 ms
```
## Performance after improvement
```
$ ping -c 10 192.168.6.6
PING 192.168.6.6 (192.168.6.6) 56(84) bytes of data.
64 bytes from 192.168.6.6: icmp_seq=1 ttl=254 time=10.1 ms
64 bytes from 192.168.6.6: icmp_seq=2 ttl=254 time=3.66 ms
64 bytes from 192.168.6.6: icmp_seq=3 ttl=254 time=25.8 ms
64 bytes from 192.168.6.6: icmp_seq=4 ttl=254 time=6.53 ms
64 bytes from 192.168.6.6: icmp_seq=5 ttl=254 time=9.93 ms
64 bytes from 192.168.6.6: icmp_seq=6 ttl=254 time=6.07 ms
64 bytes from 192.168.6.6: icmp_seq=7 ttl=254 time=5.44 ms
64 bytes from 192.168.6.6: icmp_seq=8 ttl=254 time=25.6 ms
64 bytes from 192.168.6.6: icmp_seq=9 ttl=254 time=51.3 ms
64 bytes from 192.168.6.6: icmp_seq=10 ttl=254 time=79.7 ms

--- 192.168.6.6 ping statistics ---
10 packets transmitted, 10 received, 0% packet loss, time 9017ms
rtt min/avg/max/mdev = 3.655/22.416/79.689/23.670 ms
```